### PR TITLE
Enable the user to customize the link of post. Stop the user from leaving the link empty any more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ db.json
 db.backup.json
 
 /index.html
+/about.html
 /post
 /p
 /build

--- a/app/index.js
+++ b/app/index.js
@@ -218,13 +218,12 @@ module.exports = function (_env) {
    * Edit a post
    */
   app.use(route.post('/post/:link/edit', function *(link) {
-    post.edit(link, this.request.body);
+    let newLink = post.edit(link, this.request.body);
 
-    this.redirect('/post/' + link);
+    this.redirect('/post/' + newLink);
 
-    // write index.html
     saveIndex();
-    savePost(link);
+    savePost(newLink);
   }));
 
   /**

--- a/app/view/post-edit.ejs
+++ b/app/view/post-edit.ejs
@@ -3,6 +3,9 @@
   <form id="post_form" method="POST">
     <article>
       <h2><input type="text" name="title" placeholder="Title" value="<%= post.title %>" autocomplete="off"></h2>
+      <p style="display: flex; display: -webkit-flex">
+        <span style="padding: 5px 5px 5px 0; color: #ccc">http://your.blog/posts/</span><input class="inline-input" style="flex: 1; -webkit-flex: 1" type="text" name="link" placeholder="link" value="<%= post.link %>" autocomplete="off">
+      </p>
       <p>
         <textarea name="content"><%= post.content %></textarea>
       </p>

--- a/app/view/post-new.ejs
+++ b/app/view/post-new.ejs
@@ -3,6 +3,9 @@
   <form id="post_form" method="POST">
     <article>
       <h2><input type="text" name="title" placeholder="Title" autocomplete="off"></h2>
+      <p style="display: flex; display: -webkit-flex">
+        <span style="padding: 5px 5px 5px 0; color: #ccc">http://your.blog/posts/</span><input class="inline-input" style="flex: 1; -webkit-flex: 1" type="text" name="link" placeholder="link" autocomplete="off">
+      </p>
       <p>
         <textarea name="content"></textarea>
       </p>

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,7 @@ const fs     = require('fs');
 const path   = require('path');
 
 const TITLE   = 'Sample Title';
+const LINK = 'sample_title';
 const CONTENT = 'Your time is limited, so don’t waste it living someone else’s life.';
 
 describe('innsbruck', () => {
@@ -54,12 +55,15 @@ describe('innsbruck', () => {
         .type('form')
         .send({
           title:   TITLE,
+          link: LINK,
           content: CONTENT
         })
         .expect(302, done);
     });
+
+
     it('should have created (a sample post and) a new html file', () => {
-      let filePath = path.join(__dirname, '..', 'post', '2.html');
+      let filePath = path.join(__dirname, '..', 'post', LINK + '.html');
       assert(fs.existsSync(filePath));
       assert(fs.readFileSync(filePath).toString().includes(CONTENT));
     });
@@ -71,7 +75,7 @@ describe('innsbruck', () => {
         })
         .expect(200, () => {
           request
-            .get('/post/2')
+            .get('/post/' + LINK)
             .expect(res => {
               assert(res.text.includes(CONTENT));
             })


### PR DESCRIPTION
**Outcome**: 

Enable the user to customize the link of post. Stop the user from leaving the link empty any more.

**Action**:

1. modify app/view/post-edit.ejs && app/view/post-new.ejs to add the link input.

2. modify app/index.js to make sure the new edit works.

3. modify app/post/index.js, to use a common generated_post() for both
new() and edit()

4. modify test/test.js to make the test compatible for customized link.